### PR TITLE
Fix internal aliasing in incremental delete

### DIFF
--- a/macros/materializations/base_incremental/common/get_delete_sql.sql
+++ b/macros/materializations/base_incremental/common/get_delete_sql.sql
@@ -1,0 +1,14 @@
+{#
+Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
+#}
+{% macro default__get_delete_sql(target, source, unique_key) -%}
+  delete from {{ target }}
+  where ({{ unique_key }}) in (
+    select {{ unique_key }}
+    from {{ source }}
+  )
+{%- endmacro %}
+

--- a/macros/materializations/base_incremental/common/get_merge_sql.sql
+++ b/macros/materializations/base_incremental/common/get_merge_sql.sql
@@ -45,7 +45,7 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
 
         -- use those calculated min + max values to limit 'target' scan, to only the days with new data
         {% set predicate_override %}
-            DBT_INTERNAL_DEST.{{ date_column }} between '{{ lower_limit }}' and '{{ upper_limit }}'
+            {{ date_column }} between '{{ lower_limit }}' and '{{ upper_limit }}'
         {% endset %}
     {% endif %}
 


### PR DESCRIPTION
## Summary
- remove internal aliases from delete statements with new `get_delete_sql`
- drop internal alias reference in merge predicate

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68496e048d80832f8ccd7213f715c7dd